### PR TITLE
Remember last file when activity dies. Fixes #15.

### DIFF
--- a/app/src/main/res/layout/activity_reader.xml
+++ b/app/src/main/res/layout/activity_reader.xml
@@ -28,11 +28,11 @@
                     android:textAlignment="textStart"
                     fontPath="fonts/ScheherazadeRegOT.ttf"
                     android:layout_width="match_parent"
-                    android:layout_height="match_parent"
+                    android:layout_height="wrap_content"
                     android:padding="10dp"
                     android:text="Default text from XML"
                     android:textIsSelectable="true"
-                    android:textSize="26sp"></TextView>
+                    android:textSize="26sp"/>
             </ScrollView>
             <View
                 android:id="@+id/view_toolbar_shadow"


### PR DESCRIPTION
When an orientation change occurs, we start all over from onCreate.
As a result, we need to save important state (like which book file
we were last reading from) and restore that from savedInstanceState
instead of using the default values.

Also fixed some bugs, and replaced the reading code.
