### PR TITLE
Fix actionbar title disappearing. Fixes #19.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,9 @@
     package="com.khalid.ajrumiyyah">
     android:versionCode="1"
     android:versionName="@string/version_name">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
@@ -20,7 +23,7 @@
         </activity>
         <activity
             android:name=".PreferencesActivity"
-            android:label="@string/title_activity_preferences"></activity>
+            android:label="@string/title_activity_preferences"/>
         <activity
             android:name=".AboutActivity"
             android:label="@string/title_activity_about"
@@ -33,6 +36,4 @@
             android:name="io.fabric.ApiKey"
             android:value="7d916a731175b056ceea302c933059b591ca2646" />
     </application>
-
-    <uses-permission android:name="android.permission.INTERNET" />
 </manifest>

--- a/app/src/main/java/com/khalid/ajrumiyyah/ReaderActivity.java
+++ b/app/src/main/java/com/khalid/ajrumiyyah/ReaderActivity.java
@@ -1,5 +1,10 @@
 package com.khalid.ajrumiyyah;
 
+import com.crashlytics.android.Crashlytics;
+import com.khalid.ajrumiyyah.adapter.ChapterAdapter;
+import com.khalid.ajrumiyyah.loader.ChapterLoader;
+import com.khalid.ajrumiyyah.model.Chapter;
+
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -21,11 +26,6 @@ import android.view.View;
 import android.widget.AdapterView;
 import android.widget.ListView;
 import android.widget.TextView;
-
-import com.crashlytics.android.Crashlytics;
-import com.khalid.ajrumiyyah.adapter.ChapterAdapter;
-import com.khalid.ajrumiyyah.loader.ChapterLoader;
-import com.khalid.ajrumiyyah.model.Chapter;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -156,7 +156,8 @@ public class ReaderActivity extends ActionBarActivity
         mLastHref = "cover.html";
         if (savedInstanceState != null) {
             mLastHref = savedInstanceState.getString(SI_LAST_CHAPTER, mLastHref);
-            tvActionBarTitle.setText(savedInstanceState.getString(SI_ACTION_BAR_TITLE, mActionBarTitle));
+            mActionBarTitle = savedInstanceState.getString(SI_ACTION_BAR_TITLE);
+            tvActionBarTitle.setText(mActionBarTitle);
         }
         setTextViewWithContent(mLastHref);
 


### PR DESCRIPTION
- i moved `uses-permission` above `application` since that's the "standard."
- android studio re-ordered the imports, sorry about that.

basically, you weren't saving the updated `mActionBarTitle` - consequently, the next time you switched orientation, it was `null`, so you were saving `null` and then setting the title to `null`.
